### PR TITLE
pers_ipc_dbus: remove deprecated glib init

### DIFF
--- a/src/pers_ipc_dbus.c
+++ b/src/pers_ipc_dbus.c
@@ -1407,9 +1407,6 @@ static void*	persIpcPASLoopThread(void *lpParam)
 {
 	uint32_t 		u32ConnectionId 	= 0;
 
-	/* Initialize glib */
-	g_type_init();			/* deprecated. Since GLib 2.36, the type system is initialized automatically and this function does nothing.*/
-
 	/* Create the main loop */
 	g_pPASMainLoop = g_main_loop_new(NIL, FALSE);
 	if(NIL == g_pPASMainLoop)
@@ -1465,9 +1462,6 @@ static void*	persIpcPASLoopThread(void *lpParam)
 static void* 	persIpcPCLLoopThread(void *lpParam)
 {
 	GError 	*pGError 			= NIL;
-
-	/* Initialize glib */
-	g_type_init();			/* deprecated. Since GLib 2.36, the type system is initialized automatically and this function does nothing.*/
 
 	/* Create the main loop */
 	g_pPCLMainLoop = g_main_loop_new(NIL, FALSE);


### PR DESCRIPTION
As the comment states the g_type_init function calls are deprecated. It
still produces build warnings and as such it is better to remove it.

../src/pers_ipc_dbus.c:1411:2: warning: ‘g_type_init’ is deprecated
[-Wdeprecated-declarations]

../src/pers_ipc_dbus.c:1470:2: warning: ‘g_type_init’ is deprecated
[-Wdeprecated-declarations]

Signed-off-by: Gordan Markuš <gordan.markus@pelagicore.com>